### PR TITLE
feat: Add nextgen namespace configuration with RBAC, quotas and limits

### DIFF
--- a/nextgen-namespace/group.yaml
+++ b/nextgen-namespace/group.yaml
@@ -1,0 +1,10 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: nextgen-team
+users:
+  - amr
+  - ezz
+  - abdullah
+  - yassine
+

--- a/nextgen-namespace/kustomization.yaml
+++ b/nextgen-namespace/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - rolebinding-team-edit.yaml
+  - rolebinding-wael-view.yaml
+  - resourcequota.yaml
+  - limitrange.yaml
+

--- a/nextgen-namespace/kustomization.yaml
+++ b/nextgen-namespace/kustomization.yaml
@@ -2,8 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - group.yaml
   - rolebinding-team-edit.yaml
   - rolebinding-wael-view.yaml
   - resourcequota.yaml
   - limitrange.yaml
+
 

--- a/nextgen-namespace/limitrange.yaml
+++ b/nextgen-namespace/limitrange.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: nextgen-limits
+  namespace: nextgen
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: "500m"
+        memory: "512Mi"
+      defaultRequest:
+        cpu: "200m"
+        memory: "256Mi"
+

--- a/nextgen-namespace/limitrange.yaml
+++ b/nextgen-namespace/limitrange.yaml
@@ -13,3 +13,4 @@ spec:
         cpu: "200m"
         memory: "256Mi"
 
+

--- a/nextgen-namespace/namespace.yaml
+++ b/nextgen-namespace/namespace.yaml
@@ -5,3 +5,4 @@ metadata:
   labels:
     name: nextgen
 
+

--- a/nextgen-namespace/namespace.yaml
+++ b/nextgen-namespace/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nextgen
+  labels:
+    name: nextgen
+

--- a/nextgen-namespace/resourcequota.yaml
+++ b/nextgen-namespace/resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: nextgen-quota
+  namespace: nextgen
+spec:
+  hard:
+    pods: "10"
+    limits.cpu: "2"
+    limits.memory: "12Gi"
+

--- a/nextgen-namespace/resourcequota.yaml
+++ b/nextgen-namespace/resourcequota.yaml
@@ -9,3 +9,4 @@ spec:
     limits.cpu: "2"
     limits.memory: "12Gi"
 
+

--- a/nextgen-namespace/rolebinding-team-edit.yaml
+++ b/nextgen-namespace/rolebinding-team-edit.yaml
@@ -12,3 +12,4 @@ roleRef:
   kind: ClusterRole
   name: edit
 
+

--- a/nextgen-namespace/rolebinding-team-edit.yaml
+++ b/nextgen-namespace/rolebinding-team-edit.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: team-edit
+  namespace: nextgen
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: nextgen-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+

--- a/nextgen-namespace/rolebinding-wael-view.yaml
+++ b/nextgen-namespace/rolebinding-wael-view.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: view
+  namespace: nextgen
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: wael
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+

--- a/nextgen-namespace/rolebinding-wael-view.yaml
+++ b/nextgen-namespace/rolebinding-wael-view.yaml
@@ -12,3 +12,4 @@ roleRef:
   kind: ClusterRole
   name: view
 
+


### PR DESCRIPTION
- Create nextgen namespace
- Add RoleBinding for nextgen-team group with edit role
- Add RoleBinding for wael user with view role
- Set ResourceQuota: 2 CPU, 12Gi memory, 10 pods
- Set LimitRange: default container limits (500m CPU, 512Mi memory)